### PR TITLE
Add gui component for audiopanel

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/wombatlord/last-player-on-the-left/src/app"
 	"github.com/wombatlord/last-player-on-the-left/src/clients"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
 	"github.com/wombatlord/last-player-on-the-left/src/lastplayer"
 	"github.com/wombatlord/last-player-on-the-left/src/view"
 	"log"
@@ -32,13 +33,13 @@ func ConfigureUI() *tview.Application {
 	gui := tview.NewApplication()
 
 	AppControllers.FeedMenu = view.NewFeedsController()
-	app.Register(AppControllers.FeedMenu)
+	domain.Register(AppControllers.FeedMenu)
 
 	AppControllers.EpisodeMenu = view.NewEpisodeMenuController()
-	app.Register(AppControllers.EpisodeMenu)
+	domain.Register(AppControllers.EpisodeMenu)
 
 	AppControllers.APViewController = view.NewAPViewController()
-	app.Register(AppControllers.APViewController)
+	domain.Register(AppControllers.APViewController)
 
 	AppControllers.RootController = view.NewRootController(gui)
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var AppControllers view.Controllers
 func ConfigureUI() *tview.Application {
 	gui := tview.NewApplication()
 
-	AppControllers.FeedMenu = view.NewFeedsController()
+	AppControllers.FeedMenu = view.NewFeedsController(gui)
 	domain.Register(AppControllers.FeedMenu)
 
 	AppControllers.EpisodeMenu = view.NewEpisodeMenuController()

--- a/main.go
+++ b/main.go
@@ -15,8 +15,6 @@ import (
 var args struct {
 	Alias        string `arg:"positional" help:"The RSS feed alias"`
 	Subscription string `arg:"-s, --subscribe" help:"Supply a URL to the feed to create a subscription with the provided alias"`
-	Latest       bool   `arg:"-l, --latest" help:"Play the latest episode associated to the alias"`
-	Episode      int    `arg:"-e, --episode" help:"Play a specific episode. 0 is the latest episode."`
 	Download     []int  `arg:"-d, --download" help:"Download episodes. 0 is the latest episode."`
 }
 
@@ -26,10 +24,6 @@ var (
 	conf   *app.ConfigFile
 	err    error
 )
-
-func playAudio(url string) {
-	lastplayer.StreamAudio("stream", url)
-}
 
 var AppControllers view.Controllers
 
@@ -90,35 +84,6 @@ func main() {
 		feed, err = clients.GetContent(sub.Url)
 	}
 	fatal(err)
-
-	// If no episode arg is provided, set value to -1 to prevent 0 value instantiation.
-	args.Episode = -1
-	// Prints data from the feed for sanity checking.
-	// feed.EpisodeData(*feed)
-
-	// Main Control flow
-	if args.Subscription != "" {
-		// Handles new Subs
-		fatal(conf.Include(args.Alias, args.Subscription))
-	}
-
-	if args.Latest {
-		// Get the url for the latest episode in the feed.
-		latest := feed.Channel[0].Item[0]
-		streamUrl := latest.Enclosure.Url
-
-		// do the latest noises
-		playAudio(streamUrl)
-	}
-
-	if args.Episode > -1 {
-		// Get the url for the requested episode in the feed.
-		episode := feed.Channel[0].Item[args.Episode]
-		streamUrl := episode.Enclosure.Url
-
-		// do the specific noises
-		playAudio(streamUrl)
-	}
 }
 
 func fatal(err error) {

--- a/main.go
+++ b/main.go
@@ -43,8 +43,16 @@ func ConfigureUI() *tview.Application {
 	AppControllers.EpisodeMenu = view.NewEpisodeMenuController()
 	app.Register(AppControllers.EpisodeMenu)
 
-	AppControllers.RootContoller = view.NewRootController(gui)
-	
+	AppControllers.APViewController = view.NewAPViewController()
+	app.Register(AppControllers.APViewController)
+
+	AppControllers.RootController = view.NewRootController(gui)
+
+	audioPanel := lastplayer.FetchAudioPanel()
+	audioPanel.SubscribeToState(AppControllers.APViewController)
+	audioPanel.AttachApp(gui)
+	audioPanel.SpawnPublisher()
+
 	application := view.Build(gui, AppControllers)
 
 	return application

--- a/src/app/state.go
+++ b/src/app/state.go
@@ -5,12 +5,15 @@ import (
 )
 
 type State struct {
-	FeedIndex      int
-	EpisodeIndex   int
-	Initialised    bool
+	FeedIndex    int
+	EpisodeIndex int
+	Initialised  bool
 }
 
 var currentState State
+
+// NoItem is used to indicate a "none" value for a menu index (i.e. a positive integer)
+const NoItem int = -1
 
 type Transform func(state State) State
 
@@ -37,7 +40,7 @@ func Register(controller Receiver) Receiver {
 // NewManager should be called to retrieve a manager instance, once commit has been called,
 func NewManager() StateManager {
 	if !currentState.Initialised {
-		currentState.FeedIndex = 0
+		currentState.FeedIndex = NoItem
 		currentState.EpisodeIndex = 0
 		currentState.Initialised = true
 	}

--- a/src/clients/tcp_audio.go
+++ b/src/clients/tcp_audio.go
@@ -61,12 +61,12 @@ func (client *ClientStreamer) String() string {
 		StreamerErr:      client.Err(),
 	}
 
-	json, err := json.Marshal(info)
+	jsonData, err := json.Marshal(info)
 	if err != nil {
-		json = []byte(err.Error())
+		jsonData = []byte(err.Error())
 	}
 
-	return string(json)
+	return string(jsonData)
 }
 
 func (client *ClientStreamer) currentStreamerExhausted() bool {
@@ -113,6 +113,9 @@ func (client *ClientStreamer) Len() int {
 }
 
 func (client *ClientStreamer) Position() int {
+	if client.currentStreamer == nil {
+		return 0
+	}
 	return client.currentStreamer.Position()
 }
 

--- a/src/domain/state.go
+++ b/src/domain/state.go
@@ -2,12 +2,15 @@ package app
 
 import (
 	"fmt"
+	"github.com/wombatlord/last-player-on-the-left/src/clients"
 )
 
 type State struct {
-	FeedIndex    int
-	EpisodeIndex int
-	Initialised  bool
+	FeedIndex      int
+	Feed           *clients.RSSFeed
+	EpisodeIndex   int
+	PlayingEpisode *clients.Item
+	Initialised    bool
 }
 
 var currentState State
@@ -41,7 +44,9 @@ func Register(controller Receiver) Receiver {
 func NewManager() StateManager {
 	if !currentState.Initialised {
 		currentState.FeedIndex = NoItem
+		currentState.Feed = nil
 		currentState.EpisodeIndex = 0
+		currentState.PlayingEpisode = nil
 		currentState.Initialised = true
 	}
 	return StateManager{

--- a/src/domain/state.go
+++ b/src/domain/state.go
@@ -1,7 +1,8 @@
-package app
+package domain
 
 import (
 	"fmt"
+	"github.com/wombatlord/last-player-on-the-left/src/app"
 	"github.com/wombatlord/last-player-on-the-left/src/clients"
 )
 
@@ -22,7 +23,7 @@ type Transform func(state State) State
 
 type StateManager struct {
 	next    State
-	subs    []Subscription
+	subs    []app.Subscription
 	dirty   bool
 	pending []Transform
 	logger  chan string
@@ -51,10 +52,10 @@ func NewManager() StateManager {
 	}
 	return StateManager{
 		currentState,
-		conf.Config.Subs,
+		app.LoadedConfig.Subs,
 		false,
 		[]Transform{},
-		GetLogChan("StateManager"),
+		app.GetLogChan("StateManager"),
 	}
 }
 

--- a/src/lastplayer/lastplayer.go
+++ b/src/lastplayer/lastplayer.go
@@ -43,12 +43,19 @@ type AudioPanel struct {
 	subscribers []PlayerStateSubscriber
 	gui         *tview.Application
 	ticker      *time.Ticker
+	Format      beep.Format
 }
 
 func (ap *AudioPanel) PlayPause() {
 	speaker.Lock()
 	ap.ctrl.Paused = !ap.ctrl.Paused
 	speaker.Unlock()
+}
+
+func (ap *AudioPanel) Duration(e clients.Enclosure) time.Duration {
+	byteCount := int(e.Length)
+	numSamples := byteCount / ap.Format.Width()
+	return ap.sampleRate.D(numSamples)
 }
 
 // FetchAudioPanel will return the already initialised panel pointer.
@@ -65,6 +72,7 @@ func (ap *AudioPanel) AttachApp(gui *tview.Application) {
 }
 
 func (ap *AudioPanel) SetStreamer(format beep.Format, streamer beep.StreamSeeker) {
+	ap.Format = format
 	ap.streamer = streamer
 	ap.sampleRate = format.SampleRate
 	ap.ctrl = &beep.Ctrl{Streamer: beep.Loop(-1, streamer)}            // used for pausing

--- a/src/lastplayer/lastplayer.go
+++ b/src/lastplayer/lastplayer.go
@@ -2,30 +2,17 @@ package lastplayer
 
 import (
 	"fmt"
+	"github.com/faiface/beep"
+	"github.com/faiface/beep/effects"
+	"github.com/faiface/beep/speaker"
 	"github.com/rivo/tview"
+	"github.com/wombatlord/last-player-on-the-left/src/app"
+	"github.com/wombatlord/last-player-on-the-left/src/clients"
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"time"
-	"unicode"
-
-	"github.com/faiface/beep"
-	"github.com/faiface/beep/effects"
-	"github.com/faiface/beep/mp3"
-	"github.com/faiface/beep/speaker"
-	"github.com/gdamore/tcell"
-	"github.com/wombatlord/last-player-on-the-left/src/app"
-	"github.com/wombatlord/last-player-on-the-left/src/clients"
 )
-
-// drawTextLine is a convenience function for drawing text
-func drawTextLine(screen tcell.Screen, x, y int, s string, style tcell.Style) {
-	for _, r := range s {
-		screen.SetContent(x, y, r, nil, style)
-		x++
-	}
-}
 
 var (
 	panel = &AudioPanel{}
@@ -62,14 +49,6 @@ func (ap *AudioPanel) PlayPause() {
 	speaker.Lock()
 	ap.ctrl.Paused = !ap.ctrl.Paused
 	speaker.Unlock()
-}
-
-// InitAudioPanel is a constructor function for the AudioPanel struct.
-func InitAudioPanel(format beep.Format, streamer beep.StreamSeeker) *AudioPanel {
-	getLogger() <- "Building audio panel"
-	panel.subscribers = []PlayerStateSubscriber{}
-	panel.SetStreamer(format, streamer)
-	return panel
 }
 
 // FetchAudioPanel will return the already initialised panel pointer.
@@ -164,216 +143,4 @@ func (ap *AudioPanel) GetPlayerState() PlayerState {
 	}
 
 	return state
-}
-
-// Drawing
-func (ap *AudioPanel) draw(screen tcell.Screen) {
-	mainStyle := tcell.StyleDefault.
-		Background(tcell.NewHexColor(0x473437)).
-		Foreground(tcell.NewHexColor(0xD7D8A2))
-	statusStyle := mainStyle.
-		Foreground(tcell.NewHexColor(0xDDC074)).
-		Bold(true)
-
-	screen.Fill(' ', mainStyle)
-
-	drawTextLine(screen, 0, 0, "This is the Last Player...ON THE LEFT!", mainStyle)
-	drawTextLine(screen, 0, 1, "Press [ESC] to quit.", mainStyle)
-	drawTextLine(screen, 0, 2, "Press [SPACE] to pause/resume.", mainStyle)
-	drawTextLine(screen, 0, 3, "Use keys in (?/?) to turn the buttons.", mainStyle)
-
-	speaker.Lock()
-	position := ap.sampleRate.D(ap.streamer.Position())
-	length := ap.sampleRate.D(ap.streamer.Len())
-	volume := ap.volume.Volume
-	speed := ap.resampler.Ratio()
-	speaker.Unlock()
-
-	positionStatus := fmt.Sprintf("%v / %v", position.Round(time.Second), length.Round(time.Second))
-	volumeStatus := fmt.Sprintf("%.1f", volume)
-	speedStatus := fmt.Sprintf("%.3fx", speed)
-
-	drawTextLine(screen, 0, 5, "Position (Q/W):", mainStyle)
-	drawTextLine(screen, 16, 5, positionStatus, statusStyle)
-
-	drawTextLine(screen, 0, 6, "Volume   (A/S):", mainStyle)
-	drawTextLine(screen, 16, 6, volumeStatus, statusStyle)
-
-	drawTextLine(screen, 0, 7, "Speed    (Z/X):", mainStyle)
-	drawTextLine(screen, 16, 7, speedStatus, statusStyle)
-}
-
-// AppEvent handling
-func (ap *AudioPanel) handle(eventInstance tcell.Event) (changed, quit bool) {
-	switch event := eventInstance.(type) {
-	case *tcell.EventKey:
-		getLogger() <- fmt.Sprintf("Handling AppEvent. Type: %T, Name: %s", eventInstance, event.Name())
-		if event.Key() == tcell.KeyESC {
-			return false, true
-		}
-
-		if event.Key() != tcell.KeyRune {
-			return false, false
-		}
-
-		switch unicode.ToLower(event.Rune()) {
-		case ' ':
-			speaker.Lock()
-			ap.ctrl.Paused = !ap.ctrl.Paused
-			speaker.Unlock()
-			return false, false
-
-		case 'q', 'w':
-			speaker.Lock()
-			newPos := ap.streamer.Position()
-			if event.Rune() == 'q' {
-				newPos -= ap.sampleRate.N(time.Second)
-			}
-			if event.Rune() == 'w' {
-				newPos += ap.sampleRate.N(time.Second)
-			}
-			if newPos < 0 {
-				newPos = 0
-			}
-			if newPos >= ap.streamer.Len() {
-				newPos = ap.streamer.Len() - 1
-			}
-
-			if err := ap.streamer.Seek(newPos); err != nil {
-				log.Fatal(err)
-			}
-			speaker.Unlock()
-			return true, false
-
-		case 'a':
-			speaker.Lock()
-			ap.volume.Volume -= 0.1
-			speaker.Unlock()
-			return true, false
-
-		case 's':
-			speaker.Lock()
-			ap.volume.Volume += 0.1
-			speaker.Unlock()
-			return true, false
-
-		case 'z':
-			speaker.Lock()
-			ap.resampler.SetRatio(ap.resampler.Ratio() * 15 / 16)
-			speaker.Unlock()
-			return true, false
-
-		case 'x':
-			speaker.Lock()
-			ap.resampler.SetRatio(ap.resampler.Ratio() * 16 / 15)
-			speaker.Unlock()
-			return true, false
-		}
-	}
-	return false, false
-}
-
-// StreamAudio is a proof of concept audio playback via tweaked Beep example code.
-// mp3.Decode requires an io.ReadCloser
-// This is provided by os.Open() for local playback
-// audioRequest() provides the io.ReadCloser from a HTTP Response body for streaming from a link.
-func StreamAudio(source string, audioSource string) {
-	switch source {
-	case "local":
-		audioLocal, err := os.Open(audioSource)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		streamer, format, err := mp3.Decode(audioLocal)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer func(streamer beep.StreamSeekCloser) {
-			err := streamer.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}(streamer)
-
-		_ = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
-
-		done := make(chan bool)
-		speaker.Play(beep.Seq(streamer, beep.Callback(func() {
-			done <- true
-		})))
-		<-done
-
-	case "stream":
-		audio, err := AudioRequest(audioSource)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		streamer, format, err := clients.StreamDecode(audio)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer func(streamer *clients.ClientStreamer) {
-			err := streamer.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}(streamer)
-
-		err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		screen, err := tcell.NewScreen()
-		if err != nil {
-			panic(err)
-		}
-		err = screen.Init()
-		if err != nil {
-			panic(err)
-		}
-
-		ap := InitAudioPanel(format, streamer)
-
-		defer func() {
-			screen.Fini()
-		}()
-
-		ap.play()
-
-		// partial prototyping to move away from beep.Seq(... func() {done <- true}) in ap.play()
-		events := make(chan tcell.Event)
-
-		go func() {
-			for {
-				events <- screen.PollEvent()
-			}
-		}()
-
-		t := time.NewTicker(time.Second)
-		defer t.Stop()
-
-	loop:
-		for {
-			select {
-			case event := <-events:
-				changed, quit := ap.handle(event)
-				if quit {
-					getLogger() <- "Exiting"
-					break loop
-				}
-				if changed {
-					screen.Clear()
-					ap.draw(screen)
-					screen.Show()
-				}
-			case <-t.C:
-				screen.Clear()
-				ap.draw(screen)
-				screen.Show()
-			}
-		}
-	}
 }

--- a/src/view/ap_view_controller.go
+++ b/src/view/ap_view_controller.go
@@ -1,0 +1,44 @@
+package view
+
+import (
+	"fmt"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/wombatlord/last-player-on-the-left/src/app"
+	"github.com/wombatlord/last-player-on-the-left/src/lastplayer"
+	"time"
+)
+
+type APViewController struct {
+	TextViewController
+	lastplayer.PlayerStateSubscriber
+	view   *tview.TextView
+	logger chan string
+	ticker *time.Ticker
+}
+
+func NewAPViewController() *APViewController {
+	return &APViewController{logger: app.GetLogChan("APViewController")}
+}
+
+func (a *APViewController) Attach(textView *tview.TextView) {
+	a.view = textView
+}
+
+func (a *APViewController) OnUpdate() {
+	state := lastplayer.FetchAudioPanel().GetPlayerState()
+	a.logger <- fmt.Sprintf("OnUpdate called with state %+v", state)
+	a.view.SetText(fmt.Sprintf("STATE: %+v", state))
+}
+
+func (a *APViewController) View() *tview.TextView {
+	return a.view
+}
+
+func (a *APViewController) Receive(state app.State) {
+	a.logger <- fmt.Sprintf("Received state %+v", state)
+}
+
+func (a *APViewController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
+	return event
+}

--- a/src/view/ap_view_controller.go
+++ b/src/view/ap_view_controller.go
@@ -5,6 +5,8 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/wombatlord/last-player-on-the-left/src/app"
+	"github.com/wombatlord/last-player-on-the-left/src/clients"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
 	"github.com/wombatlord/last-player-on-the-left/src/lastplayer"
 	"time"
 )
@@ -12,9 +14,11 @@ import (
 type APViewController struct {
 	TextViewController
 	lastplayer.PlayerStateSubscriber
-	view   *tview.TextView
-	logger chan string
-	ticker *time.Ticker
+	view           *tview.TextView
+	logger         chan string
+	ticker         *time.Ticker
+	feed           *clients.RSSFeed
+	playingEpisode *clients.Item
 }
 
 func NewAPViewController() *APViewController {
@@ -28,15 +32,32 @@ func (a *APViewController) Attach(textView *tview.TextView) {
 func (a *APViewController) OnUpdate() {
 	state := lastplayer.FetchAudioPanel().GetPlayerState()
 	a.logger <- fmt.Sprintf("OnUpdate called with state %+v", state)
-	a.view.SetText(fmt.Sprintf("STATE: %+v", state))
+	title := ""
+	description := ""
+	if a.playingEpisode != nil {
+		title = a.playingEpisode.Title
+		description = a.playingEpisode.Description
+	}
+	playStatus := map[bool]string{true: string(''), false: string('')}
+	playerStatus := fmt.Sprintf(
+		"%s\n%s %s/%s\n%s",
+		title,
+		playStatus[state.Playing],
+		state.Position,
+		state.Length,
+		description,
+	)
+	a.view.SetText(playerStatus)
 }
 
 func (a *APViewController) View() *tview.TextView {
 	return a.view
 }
 
-func (a *APViewController) Receive(state app.State) {
+func (a *APViewController) Receive(state domain.State) {
 	a.logger <- fmt.Sprintf("Received state %+v", state)
+	a.feed = state.Feed
+	a.playingEpisode = state.PlayingEpisode
 }
 
 func (a *APViewController) InputHandler(event *tcell.EventKey) *tcell.EventKey {

--- a/src/view/controllers.go
+++ b/src/view/controllers.go
@@ -3,13 +3,13 @@ package view
 import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"github.com/wombatlord/last-player-on-the-left/src/app"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
 )
 
 // Controller is the interface for views that are expressed
 // In terms of tview.Primitive implementations
 type Controller interface {
-	app.Receiver
+	domain.Receiver
 	InputHandler(event *tcell.EventKey) *tcell.EventKey
 }
 

--- a/src/view/display.go
+++ b/src/view/display.go
@@ -27,11 +27,10 @@ func Build(gui *tview.Application, controllers Controllers) *tview.Application {
 	mainFlex.AddItem(topRow, -1, 4, true)
 	mainFlex.AddItem(apView, -1, 1, false)
 
-	gui.SetRoot(mainFlex, true)
-
 	focusRing := []tview.Primitive{feedMenu, episodeMenu}
 	controllers.RootController.SetFocusRing(focusRing)
 
+	gui.SetRoot(mainFlex, true)
 	return gui
 }
 

--- a/src/view/display.go
+++ b/src/view/display.go
@@ -14,23 +14,24 @@ type Controllers struct {
 // the user interface adding new primitives to the app hierarchy
 // in this file
 func Build(gui *tview.Application, controllers Controllers) *tview.Application {
-	mainFlex := MainFlex(controllers)
-	feedColumn := FeedColumn()
+	mainFlex := MainFlex(controllers).SetDirection(tview.FlexRow)
+	topRow := TopRow()
 	episodeMenu := EpisodeMenu(controllers)
 	feedMenu := FeedMenu(controllers)
-	debugPanel := DebugPanel()
+	apView := AudioPanelView()
+	//
+	//feedColumn.AddItem(feedMenu, -1, 5, true)
 
-	feedColumn.AddItem(feedMenu, -1, 5, true)
-	feedColumn.AddItem(debugPanel, -1, 1, false)
+	topRow.AddItem(feedMenu, -1, 1, true)
+	topRow.AddItem(episodeMenu, -1, 1, true)
 
-	mainFlex.AddItem(feedColumn, -1, 1, true)
-	mainFlex.AddItem(episodeMenu, -1, 1, true)
+	mainFlex.AddItem(topRow, -1, 4, true)
+	mainFlex.AddItem(apView, -1, 1, false)
 
 	gui.SetRoot(mainFlex, true)
 
 	focusRing := []tview.Primitive{feedMenu, episodeMenu}
 	controllers.RootContoller.SetFocusRing(focusRing)
-
 
 	return gui
 }
@@ -42,16 +43,18 @@ func MainFlex(controllers Controllers) *tview.Flex {
 	return mainFlex
 }
 
-func FeedColumn() *tview.Flex {
-	feedColumnFlex := tview.NewFlex().SetDirection(tview.FlexRow)
-	return feedColumnFlex
+func TopRow() *tview.Flex {
+	topRow := tview.NewFlex().SetDirection(tview.FlexColumn)
+	return topRow
 }
 
 func EpisodeMenu(controllers Controllers) *tview.List {
 	episodeMenuView := tview.NewList()
 	controllers.EpisodeMenu.Attach(episodeMenuView)
 
-	episodeMenuView.SetBorder(true)
+	episodeMenuView.SetBorder(true).
+		SetTitle("Episodes").
+		SetTitleAlign(tview.AlignCenter)
 	return episodeMenuView
 }
 
@@ -59,11 +62,16 @@ func FeedMenu(controllers Controllers) *tview.List {
 	feedMenu := tview.NewList()
 	controllers.FeedMenu.Attach(feedMenu)
 
-	feedMenu.SetBorder(true)
+	feedMenu.SetBorder(true).
+		SetTitle("Podcasts").
+		SetTitleAlign(tview.AlignCenter)
 	return feedMenu
 }
 
-func DebugPanel() *tview.TextView {
+func AudioPanelView() *tview.TextView {
 	view := tview.NewTextView()
+	view.SetBorder(true).
+		SetTitle("Player").
+		SetTitleAlign(tview.AlignCenter)
 	return view
 }

--- a/src/view/display.go
+++ b/src/view/display.go
@@ -5,9 +5,10 @@ import (
 )
 
 type Controllers struct {
-	FeedMenu      *FeedsMenuController
-	EpisodeMenu   *EpisodeMenuController
-	RootContoller *RootContoller
+	FeedMenu         *FeedsMenuController
+	EpisodeMenu      *EpisodeMenuController
+	RootController   *RootController
+	APViewController *APViewController
 }
 
 // Build returns the tview app, implement any additions to
@@ -18,9 +19,7 @@ func Build(gui *tview.Application, controllers Controllers) *tview.Application {
 	topRow := TopRow()
 	episodeMenu := EpisodeMenu(controllers)
 	feedMenu := FeedMenu(controllers)
-	apView := AudioPanelView()
-	//
-	//feedColumn.AddItem(feedMenu, -1, 5, true)
+	apView := AudioPanelView(controllers)
 
 	topRow.AddItem(feedMenu, -1, 1, true)
 	topRow.AddItem(episodeMenu, -1, 1, true)
@@ -31,14 +30,14 @@ func Build(gui *tview.Application, controllers Controllers) *tview.Application {
 	gui.SetRoot(mainFlex, true)
 
 	focusRing := []tview.Primitive{feedMenu, episodeMenu}
-	controllers.RootContoller.SetFocusRing(focusRing)
+	controllers.RootController.SetFocusRing(focusRing)
 
 	return gui
 }
 
 func MainFlex(controllers Controllers) *tview.Flex {
 	mainFlex := tview.NewFlex()
-	controllers.RootContoller.Attach(mainFlex)
+	controllers.RootController.Attach(mainFlex)
 
 	return mainFlex
 }
@@ -68,8 +67,10 @@ func FeedMenu(controllers Controllers) *tview.List {
 	return feedMenu
 }
 
-func AudioPanelView() *tview.TextView {
+func AudioPanelView(controllers Controllers) *tview.TextView {
 	view := tview.NewTextView()
+	controllers.APViewController.Attach(view)
+
 	view.SetBorder(true).
 		SetTitle("Player").
 		SetTitleAlign(tview.AlignCenter)

--- a/src/view/episode_menu.go
+++ b/src/view/episode_menu.go
@@ -61,7 +61,8 @@ func (e *EpisodeMenuController) Receive(s app.State) {
 func (e *EpisodeMenuController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	if event.Key() == tcell.KeyEnter {
 		episodeIndex := e.view.GetCurrentItem()
-		lastplayer.FetchAudioPanel().PlayFromUrl(e.feed.Channel[0].Item[episodeIndex].Enclosure.Url)
+		panel := lastplayer.FetchAudioPanel()
+		panel.PlayFromUrl(e.feed.Channel[0].Item[episodeIndex].Enclosure.Url)
 		return nil
 	}
 

--- a/src/view/episode_menu.go
+++ b/src/view/episode_menu.go
@@ -2,24 +2,25 @@ package view
 
 import (
 	"fmt"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/wombatlord/last-player-on-the-left/src/app"
 	"github.com/wombatlord/last-player-on-the-left/src/clients"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
 	"github.com/wombatlord/last-player-on-the-left/src/lastplayer"
 )
 
 type EpisodeMenuController struct {
 	BaseMenuController
-	feed      *clients.RSSFeed
-	feedIndex int
-	view      *tview.List
-	logger    chan string
+	feed           *clients.RSSFeed
+	feedIndex      int
+	playingEpisode *clients.Item
+	view           *tview.List
+	logger         chan string
 }
 
 func NewEpisodeMenuController() *EpisodeMenuController {
-	return &EpisodeMenuController{feedIndex: -1, logger: app.GetLogChan("EpisodeMenuController")}
+	return &EpisodeMenuController{feedIndex: domain.NoItem, logger: app.GetLogChan("EpisodeMenuController")}
 }
 
 func (e *EpisodeMenuController) Attach(list *tview.List) {
@@ -34,10 +35,14 @@ func (e *EpisodeMenuController) OnSelectionChange(
 	_ string,
 	_ rune,
 ) {
-	manager := app.NewManager()
+	e.highlightEpisode()
+}
+
+func (e *EpisodeMenuController) highlightEpisode() {
+	manager := domain.NewManager()
 	manager.QueueTransform(
-		func(state app.State) app.State {
-			state.EpisodeIndex = index
+		func(state domain.State) domain.State {
+			state.EpisodeIndex = e.view.GetCurrentItem()
 			return state
 		},
 	)
@@ -45,11 +50,28 @@ func (e *EpisodeMenuController) OnSelectionChange(
 	manager.Commit()
 }
 
+func (e *EpisodeMenuController) playEpisode() {
+	episodeIndex := e.view.GetCurrentItem()
+	e.playingEpisode = &e.feed.Channel[0].Item[episodeIndex]
+
+	panel := lastplayer.FetchAudioPanel()
+	panel.PlayFromUrl(e.playingEpisode.Enclosure.Url)
+
+	manager := domain.NewManager()
+	manager.QueueTransform(
+		func(state domain.State) domain.State {
+			state.PlayingEpisode = e.playingEpisode
+			return state
+		},
+	)
+	manager.Commit()
+}
+
 // Receive is looking out for changes to the feed index
-func (e *EpisodeMenuController) Receive(s app.State) {
+func (e *EpisodeMenuController) Receive(s domain.State) {
+	e.feed = s.Feed
 	e.logger <- fmt.Sprintf("Received state: %+v", s)
-	if e.feedIndex == -1 || e.feedIndex != s.FeedIndex {
-		e.feed, _ = clients.GetContent(app.LoadedConfig.Subs[s.FeedIndex].Url)
+	if e.feedIndex == domain.NoItem || e.feedIndex != s.FeedIndex {
 		e.feedIndex = s.FeedIndex
 		e.view.Clear()
 		for _, item := range e.feed.Channel[0].Item {
@@ -60,9 +82,7 @@ func (e *EpisodeMenuController) Receive(s app.State) {
 
 func (e *EpisodeMenuController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	if event.Key() == tcell.KeyEnter {
-		episodeIndex := e.view.GetCurrentItem()
-		panel := lastplayer.FetchAudioPanel()
-		panel.PlayFromUrl(e.feed.Channel[0].Item[episodeIndex].Enclosure.Url)
+		e.playEpisode()
 		return nil
 	}
 

--- a/src/view/feed_menu.go
+++ b/src/view/feed_menu.go
@@ -5,15 +5,19 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/wombatlord/last-player-on-the-left/src/app"
+	"github.com/wombatlord/last-player-on-the-left/src/clients"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
+	"log"
 )
 
 // FeedsMenuController manages the feeds menu, it synchronises the
 // current feed with the feed selection in the ui
 type FeedsMenuController struct {
 	BaseMenuController
-	view      *tview.List
-	feedIndex int
-	logger    chan string
+	view                  *tview.List
+	hightlightedFeedIndex int
+	feed                  *clients.RSSFeed
+	logger                chan string
 }
 
 func NewFeedsController() *FeedsMenuController {
@@ -26,7 +30,7 @@ func (f *FeedsMenuController) Attach(list *tview.List) {
 	for _, sub := range app.LoadedConfig.Subs {
 		list.AddItem(sub.Alias, sub.Url, 0, nil)
 	}
-	f.feedIndex = list.GetCurrentItem()
+	f.hightlightedFeedIndex = list.GetCurrentItem()
 	f.view = list
 }
 
@@ -36,29 +40,45 @@ func (f *FeedsMenuController) OnSelectionChange(
 	secondaryText string,
 	shortcut rune,
 ) {
-	f.feedIndex = index
-	//f.updateFeedIndex(index)
+	var err error
+	if secondaryText != "" {
+		f.hightlightedFeedIndex = index
+	}
+	if err != nil {
+		f.logger <- fmt.Sprintf("Error occurred while attempting to retrieve the feed: %s", err.Error())
+	}
+	//f.selectFeed(index)
 }
 
-func (f *FeedsMenuController) updateFeedIndex(index int) {
-	manager := app.NewManager()
-	f.logger <- fmt.Sprintf("Pushing feed index %d to state", index)
+// selectFeed updates the UI with the new feed as selected by the user
+func (f *FeedsMenuController) selectFeed() {
+	f.logger <- fmt.Sprintf("Pushing feed index %d to state", f.hightlightedFeedIndex)
+	index := f.view.GetCurrentItem()
+	var err error
+	_, url := f.view.GetItemText(index)
+	f.feed, err = clients.GetContent(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	manager := domain.NewManager()
 	manager.QueueTransform(
-		func(state app.State) app.State {
-			state.FeedIndex = index
+		func(state domain.State) domain.State {
+			state.FeedIndex = f.hightlightedFeedIndex
+			state.Feed = f.feed
 			return state
 		},
 	)
 	manager.Commit()
 }
 
-func (f *FeedsMenuController) Receive(s app.State) {
+func (f *FeedsMenuController) Receive(s domain.State) {
 	f.logger <- fmt.Sprintf("Received state: %+v", s)
 }
 
 func (f *FeedsMenuController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	if event.Key() == tcell.KeyEnter {
-		f.updateFeedIndex(f.view.GetCurrentItem())
+		f.selectFeed()
 	}
 	return event
 }

--- a/src/view/feed_menu.go
+++ b/src/view/feed_menu.go
@@ -48,7 +48,6 @@ func (f *FeedsMenuController) OnSelectionChange(
 	if err != nil {
 		f.logger <- fmt.Sprintf("Error occurred while attempting to retrieve the feed: %s", err.Error())
 	}
-	//f.selectFeed(index)
 }
 
 // selectFeed updates the UI with the new feed as selected by the user

--- a/src/view/feed_menu.go
+++ b/src/view/feed_menu.go
@@ -26,6 +26,7 @@ func (f *FeedsMenuController) Attach(list *tview.List) {
 	for _, sub := range app.LoadedConfig.Subs {
 		list.AddItem(sub.Alias, sub.Url, 0, nil)
 	}
+	f.feedIndex = list.GetCurrentItem()
 	f.view = list
 }
 
@@ -41,7 +42,7 @@ func (f *FeedsMenuController) OnSelectionChange(
 
 func (f *FeedsMenuController) updateFeedIndex(index int) {
 	manager := app.NewManager()
-
+	f.logger <- fmt.Sprintf("Pushing feed index %d to state", index)
 	manager.QueueTransform(
 		func(state app.State) app.State {
 			state.FeedIndex = index

--- a/src/view/root_controller.go
+++ b/src/view/root_controller.go
@@ -42,15 +42,9 @@ func (r *RootController) View() *tview.Flex {
 func (r *RootController) Receive(_ domain.State) {}
 
 func (r *RootController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
-	var focusIndex int
 
 	if event.Key() == tcell.KeyTab {
-		for i := 0; i < 2; i++ {
-			if r.focusRing[i] == r.gui.GetFocus() {
-				focusIndex = i
-				r.logger <- fmt.Sprintf("%+v", focusIndex)
-			}
-		}
+		focusIndex := r.focusRingIndex()
 
 		focusIndex += 1
 		focusIndex = focusIndex % len(r.focusRing)
@@ -75,4 +69,19 @@ func (r *RootController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 
 	return event
 
+}
+
+func (r *RootController) focusRingIndex() int {
+	var focusIndex int
+	for i := 0; i < 2; i++ {
+		if r.focusRing[i] == r.gui.GetFocus() {
+			focusIndex = i
+			r.logger <- fmt.Sprintf("%+v", focusIndex)
+		}
+	}
+	return focusIndex
+}
+
+func (r *RootController) focusedView() tview.Primitive {
+	return r.focusRing[r.focusRingIndex()]
 }

--- a/src/view/root_controller.go
+++ b/src/view/root_controller.go
@@ -10,40 +10,37 @@ import (
 	"github.com/wombatlord/last-player-on-the-left/src/lastplayer"
 )
 
-type RootContoller struct {
+type RootController struct {
 	FlexController
-	logger chan string
-	view   *tview.Flex
-	gui    *tview.Application
+	logger    chan string
+	view      *tview.Flex
+	gui       *tview.Application
 	focusRing []tview.Primitive
 }
 
-func NewRootController(gui *tview.Application) *RootContoller {
-	return &RootContoller{
+func NewRootController(gui *tview.Application) *RootController {
+	return &RootController{
 		gui:    gui,
 		logger: app.GetLogChan("RootController"),
 	}
 }
 
-func (r *RootContoller) SetFocusRing(focusRing []tview.Primitive) {
+func (r *RootController) SetFocusRing(focusRing []tview.Primitive) {
 	r.focusRing = focusRing
 }
 
-func (r *RootContoller) Attach(root *tview.Flex) {
+func (r *RootController) Attach(root *tview.Flex) {
 	r.view = root
 	root.SetInputCapture(r.InputHandler)
 }
 
-func (r *RootContoller) View() *tview.Flex {
+func (r *RootController) View() *tview.Flex {
 	return r.view
 }
 
-func (r *RootContoller) Receive(s app.State) {}
+func (r *RootController) Receive(_ app.State) {}
 
-func (r *RootContoller) InputHandler(event *tcell.EventKey) *tcell.EventKey {
-	r.logger <- fmt.Sprintf("%+v", r.gui.GetFocus())
-
-
+func (r *RootController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	var focusIndex int
 
 	if event.Key() == tcell.KeyTab {
@@ -71,7 +68,7 @@ func (r *RootContoller) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	}
 
 	if event.Key() == tcell.KeyPause || unicode.ToLower(event.Rune()) == 'p' {
-		lastplayer.FetchAudioPanel().PlayPause() 		
+		lastplayer.FetchAudioPanel().PlayPause()
 		return nil
 	}
 

--- a/src/view/root_controller.go
+++ b/src/view/root_controller.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"fmt"
+	"github.com/wombatlord/last-player-on-the-left/src/domain"
 	"unicode"
 
 	"github.com/gdamore/tcell/v2"
@@ -38,7 +39,7 @@ func (r *RootController) View() *tview.Flex {
 	return r.view
 }
 
-func (r *RootController) Receive(_ app.State) {}
+func (r *RootController) Receive(_ domain.State) {}
 
 func (r *RootController) InputHandler(event *tcell.EventKey) *tcell.EventKey {
 	var focusIndex int


### PR DESCRIPTION
### Scope:

- Intended to create a prototype of a visual audio player panel to indicate to the user what is currently playing and the progress relative to the episode length.

### Changes:

 - Removal of the unused debug panel.
 - Addition of a basic audio player panel showing:
   - Play/Pause state
   - Current time into playing episode and the total buffered duration
   - Title of the podcast episode
   - Description (from the rss feed, could do with a sanitization pass, looking at you LPOTL)
   - Attempted to show full episode duration but not consistently supplied in feed so abandoned for now.
 - Fix for issue where a feed could not be selected if no update to the feeds pane display had occurred
 - Added focus shift to episodes menu on feed selection.
 - Removed a bunch of old prototyping implementation.