### PR TITLE
On disk episode buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.yaml
 logs/log.txt
 demos/
 scratch.go
+sample.mp3
+/cache/

--- a/src/app/config.go
+++ b/src/app/config.go
@@ -17,8 +17,9 @@ type Subscription struct {
 // Config represents all the configuration contained in a config file. It
 // specifies the config schema.
 type Config struct {
-	Subs []Subscription `yaml:"subs"`
-	Logs string         `yaml:"logs"`
+	Subs  []Subscription `yaml:"subs"`
+	Logs  string         `yaml:"logs"`
+	Cache string         `yaml:"cache"`
 }
 
 // GetByAlias returns the Subscription associated to the passed alias
@@ -45,8 +46,9 @@ var LoadedConfig Config
 var DefaultConfig = ConfigFile{
 	Path: GetPath(),
 	Config: Config{
-		Subs: []Subscription{},
-		Logs: "logs/log.txt",
+		Subs:  []Subscription{},
+		Logs:  "logs/log.txt",
+		Cache: "cache",
 	},
 }
 

--- a/src/audiopanel/lastplayer.go
+++ b/src/audiopanel/lastplayer.go
@@ -100,7 +100,7 @@ func (ap *AudioPanel) SpawnPublisher() {
 	go publisher()
 }
 
-func (ap *AudioPanel) PlayFromUrl(url string) {
+func (ap *AudioPanel) NoBufferPlayFromUrl(url string) {
 	var err error
 	ap.logger.Println("PlayFromUrl call")
 
@@ -115,6 +115,19 @@ func (ap *AudioPanel) PlayFromUrl(url string) {
 	}
 	ap.SetStreamer(format, streamer)
 
+	err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
+	if err != nil {
+		log.Fatal(err)
+	}
+	ap.play()
+}
+
+func (ap *AudioPanel) PlayFromUrl(url string) {
+	var err error
+
+	streamer, format := clients.NewChunkBufferStreamer(url)
+	ap.SetStreamer(format, streamer)
+	
 	err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 	if err != nil {
 		log.Fatal(err)

--- a/src/audiopanel/lastplayer.go
+++ b/src/audiopanel/lastplayer.go
@@ -125,9 +125,9 @@ func (ap *AudioPanel) NoBufferPlayFromUrl(url string) {
 func (ap *AudioPanel) PlayFromUrl(url string) {
 	var err error
 
-	streamer, format := clients.NewChunkBufferStreamer(url)
+	streamer, format := clients.TcpDiskBufferedStreamer(url)
 	ap.SetStreamer(format, streamer)
-	
+
 	err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 	if err != nil {
 		log.Fatal(err)

--- a/src/audiopanel/lastplayer.go
+++ b/src/audiopanel/lastplayer.go
@@ -128,10 +128,10 @@ func (ap *AudioPanel) NoBufferPlayFromUrl(url string) {
 	ap.play()
 }
 
-func (ap *AudioPanel) PlayFromUrl(url string, logger *log.Logger) {
+func (ap *AudioPanel) PlayFromUrl(url string, logger *log.Logger, cachePath string) {
 	var err error
 
-	streamer, format := clients.TcpDiskBufferedStreamer(url, logger)
+	streamer, format := clients.TcpDiskBufferedStreamer(url, logger, cachePath)
 	ap.SetStreamer(format, streamer)
 
 	err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))

--- a/src/audiopanel/lastplayer.go
+++ b/src/audiopanel/lastplayer.go
@@ -30,7 +30,7 @@ type PlayerStateSubscriber interface {
 // AudioPanel contains properties for manipulating an audio stream & drawing info to the terminal. eg. volume / seeking & position
 type AudioPanel struct {
 	sampleRate  beep.SampleRate
-	streamer    beep.StreamSeeker
+	streamer    beep.StreamSeekCloser
 	ctrl        *beep.Ctrl
 	resampler   *beep.Resampler
 	volume      *effects.Volume
@@ -77,7 +77,13 @@ func (ap *AudioPanel) SetPublishCallback(callback func(func())) {
 	ap.callback = callback
 }
 
-func (ap *AudioPanel) SetStreamer(format beep.Format, streamer beep.StreamSeeker) {
+func (ap *AudioPanel) SetStreamer(format beep.Format, streamer beep.StreamSeekCloser) {
+	speaker.Clear()
+	speaker.Lock()
+	if ap.streamer != nil {
+		_ = ap.streamer.Close()
+	}
+	speaker.Unlock()
 	ap.Format = format
 	ap.streamer = streamer
 	ap.sampleRate = format.SampleRate
@@ -122,10 +128,10 @@ func (ap *AudioPanel) NoBufferPlayFromUrl(url string) {
 	ap.play()
 }
 
-func (ap *AudioPanel) PlayFromUrl(url string) {
+func (ap *AudioPanel) PlayFromUrl(url string, logger *log.Logger) {
 	var err error
 
-	streamer, format := clients.TcpDiskBufferedStreamer(url)
+	streamer, format := clients.TcpDiskBufferedStreamer(url, logger)
 	ap.SetStreamer(format, streamer)
 
 	err = speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))

--- a/src/clients/boop.go
+++ b/src/clients/boop.go
@@ -1,0 +1,246 @@
+package clients
+
+import (
+	"fmt"
+	"github.com/faiface/beep"
+	gomp3 "github.com/hajimehoshi/go-mp3"
+	"github.com/pkg/errors"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Success is the named constructor for the case that the download completes
+// successfully
+func Success(size int64) *SizedResult {
+	return &SizedResult{Size: size, Err: nil}
+}
+
+// Fail is the named constructor for the case that the copy to disk fails
+func Fail(failure error) *SizedResult {
+	return &SizedResult{Size: 0, Err: failure}
+}
+
+// SizedResult is the struct that encapsulates the error on failure or the
+// size, either predicted or written to disk, of the corresponding data in bytes
+type SizedResult struct {
+	Size int64
+	Err  error
+}
+
+// IsSuccess returns true if the SizedResult.Err is not nil, i.e. a return
+// value of true corresponds to the file being successfully downloaded
+func (r *SizedResult) IsSuccess() bool {
+	return r.Err == nil
+}
+
+const (
+	gomp3NumChannels   = 2
+	gomp3Precision     = 2
+	gomp3BytesPerFrame = gomp3NumChannels * gomp3Precision
+)
+
+// boopDecode takes a ReadCloser containing audio data in MP3 format and returns a StreamSeekCloser,
+// which streams that audio. The Seek method will panic if rc is not io.Seeker.
+//
+// Do not close the supplied ReadSeekCloser, instead, use the Close method of the returned
+// StreamSeekCloser when you want to release the resources.
+func boopDecode(rc io.ReadCloser) (s *Decoder, format beep.Format, err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Wrap(err, "mp3")
+		}
+	}()
+	d, err := gomp3.NewDecoder(rc)
+	if err != nil {
+		return nil, beep.Format{}, err
+	}
+	format = beep.Format{
+		SampleRate:  beep.SampleRate(d.SampleRate()),
+		NumChannels: gomp3NumChannels,
+		Precision:   gomp3Precision,
+	}
+	return &Decoder{rc, d, format, 0, nil, 0}, format, nil
+}
+
+// Decoder is a ripoff of the streamer that mp3.Decode returns but with a Decoder.SetLength. All the methods
+// are identical except the Decoder.SetLength.
+type Decoder struct {
+	closer io.Closer
+	d      *gomp3.Decoder
+	f      beep.Format
+	pos    int
+	err    error
+	len    int
+}
+
+func (d *Decoder) Stream(samples [][2]float64) (n int, ok bool) {
+	if d.err != nil {
+		return 0, false
+	}
+	var tmp [gomp3BytesPerFrame]byte
+	for i := range samples {
+		dn, err := d.d.Read(tmp[:])
+		if dn == len(tmp) {
+			samples[i], _ = d.f.DecodeSigned(tmp[:])
+			d.pos += dn
+			n++
+			ok = true
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			d.err = errors.Wrap(err, "mp3")
+			break
+		}
+	}
+	return n, ok
+}
+
+func (d *Decoder) Err() error {
+	return d.err
+}
+
+func (d *Decoder) Len() int {
+	return d.len / gomp3BytesPerFrame
+}
+
+func (d *Decoder) SetLength(length int) {
+	d.len = length
+}
+
+func (d *Decoder) Position() int {
+	return d.pos / gomp3BytesPerFrame
+}
+
+func (d *Decoder) Seek(p int) error {
+	if p < 0 || d.Len() < p {
+		return fmt.Errorf("mp3: seek position %v out of range [%v, %v]", p, 0, d.Len())
+	}
+	_, err := d.d.Seek(int64(p)*gomp3BytesPerFrame, io.SeekStart)
+	if err != nil {
+		return errors.Wrap(err, "mp3")
+	}
+	d.pos = p * gomp3BytesPerFrame
+	return nil
+}
+
+func (d *Decoder) Close() error {
+	err := d.closer.Close()
+	if err != nil {
+		return errors.Wrap(err, "mp3")
+	}
+	return nil
+}
+
+// TcpDiskBufferedStreamer is basically a proxy to some hacked together beep source code, all credit to them, unless
+// the code looks a bit messy, that's probably us.
+func TcpDiskBufferedStreamer(url string) (streamer *Decoder, format beep.Format) {
+	filepath := "cache/cache.mp3"
+	var (
+		done    chan *SizedResult
+		started chan *SizedResult
+	)
+
+	if fileInfo, err := os.Stat(filepath); errors.Is(err, os.ErrNotExist) {
+		started, done = asyncDownloadAudio(filepath, url)
+	} else {
+		go func() {
+			started <- Success(fileInfo.Size())
+			done <- Success(fileInfo.Size())
+		}()
+	}
+
+	streamer, format = getStreamer(started, filepath)
+
+	go func() {
+		if result := <-done; result.IsSuccess() {
+			streamer.SetLength(int(result.Size))
+		}
+	}()
+
+	return streamer, format
+}
+
+// getStreamer uses the filesystem path of the cached audio to create the Decoder. It mirrors the interface of
+// mp3.Decode from beep
+func getStreamer(started chan *SizedResult, filepath string) (streamer *Decoder, format beep.Format) {
+	if result := <-started; result.IsSuccess() {
+		audio, err := os.Open(filepath)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		streamer, format, err = boopDecode(audio)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		streamer.SetLength(int(result.Size))
+	} else {
+		log.Fatalln(result)
+	}
+	return streamer, format
+}
+
+// asyncDownloadAudio sets off a doDownload goroutine and returns the started and done channels that
+// it will report back its progress on.
+func asyncDownloadAudio(filename, url string) (started chan *SizedResult, done chan *SizedResult) {
+	started, done = make(chan *SizedResult), make(chan *SizedResult)
+
+	go doDownload(filename, url, started, done)
+
+	return started, done
+}
+
+// doDownload will download the provided url to the filepath specified. Supply two chan error, started
+// will send nil on successful start, or an error. If started returns nil, then done will send another
+// nil if the file successfully downloaded and the error otherwise.
+func doDownload(filepath string, url string, started chan *SizedResult, done chan *SizedResult) {
+	defer close(started)
+
+	var out *os.File
+
+	// Get the data
+	resp, err := http.Get(url)
+	fmt.Printf("Content Length: %d\n", resp.ContentLength)
+	if err != nil {
+		started <- Fail(err)
+	}
+
+	// Create the file
+	out, err = os.Create(filepath)
+	if err != nil {
+		started <- Fail(err)
+	}
+
+	go func() {
+		defer func() {
+			close(done)
+		}()
+		defer func(Body io.ReadCloser) {
+			_ = Body.Close()
+		}(resp.Body)
+		defer func(out *os.File) {
+			// might need to handle this if it's an issue
+			_ = out.Close()
+		}(out)
+
+		// Get to Copyin'
+		size, copyErr := io.Copy(out, resp.Body)
+
+		// Send the result down the pipe
+		if copyErr != nil {
+			fmt.Println(copyErr)
+			done <- Fail(copyErr)
+		} else {
+			done <- Success(size)
+		}
+	}()
+
+	// Wait a little for the copy to disk to begin
+	time.Sleep(time.Second / 10)
+	// then signal the download has begun
+	started <- Success(resp.ContentLength)
+}

--- a/src/clients/boop.go
+++ b/src/clients/boop.go
@@ -146,7 +146,7 @@ func (d *Decoder) Close() error {
 
 // TcpDiskBufferedStreamer is basically a proxy to some hacked together beep source code, all credit to them, unless
 // the code looks a bit messy, that's probably us.
-func TcpDiskBufferedStreamer(url string, logger *log.Logger) (streamer *Decoder, format beep.Format) {
+func TcpDiskBufferedStreamer(url string, logger *log.Logger, cachePath string) (streamer *Decoder, format beep.Format) {
 	logger.Printf("Attempting to set up streaming audio")
 
 	var (
@@ -154,7 +154,7 @@ func TcpDiskBufferedStreamer(url string, logger *log.Logger) (streamer *Decoder,
 		started chan *SizedResult
 	)
 
-	fileName := filepath.FromSlash("./cache/" + url2FileName(url, logger))
+	fileName := filepath.FromSlash(cachePath + url2FileName(url, logger))
 
 	if fileInfo, err := os.Stat(fileName); err != nil || fileInfo.Size() == 0 {
 		logger.Printf("starting download")

--- a/src/clients/chunker.go
+++ b/src/clients/chunker.go
@@ -1,0 +1,173 @@
+package clients
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/faiface/beep"
+)
+
+const chunkSampleCount int = 1024 * 1024
+
+type ChunkBufferStreamer struct {
+	beep.StreamSeekCloser
+	currentStreamer  *ClientStreamer
+	nextStreamer     *ClientStreamer
+	Episode          string
+	totalSampleCount int
+	currentOffset    int
+	format beep.Format
+}
+
+func NewChunkBufferStreamer(url string) (*ChunkBufferStreamer, beep.Format) {
+	// Ought to make a request for the byte range corresponding
+	// to the beginning of the audio file to the chunk length
+	//
+	// Should record the value supplied in response header
+	// that is total length of the file in bytes
+	// store this value as a number of samples (we can use this to implement a len function)
+	//
+	// Need to know current chunkStart.
+	cb := &ChunkBufferStreamer{}
+	cb.Episode = url
+	cb.next()
+	return cb, cb.format
+}
+
+// Stream, seek, close, pos, length
+
+func (cb *ChunkBufferStreamer) Stream(samples [][2]float64) (int, bool) {
+	if cb.currentStreamer != nil {
+		if cb.currentStreamer.currentStreamerExhausted() {
+			n := cb.next()
+			if n == nil {
+				return cb.currentStreamer.Stream(samples)
+			}
+			cb.currentStreamer = n
+		}
+	} else {
+		n := cb.next()
+		if n == nil {
+			return cb.currentStreamer.Stream(samples)
+		}
+		cb.currentStreamer = n
+	}
+
+	return cb.currentStreamer.Stream(samples)
+}
+
+func (cb *ChunkBufferStreamer) Seek(p int) error {
+	beforeCurrentOffset := p < cb.currentOffset 
+	afterNextEnd := p > cb.currentOffset + chunkSampleCount * 2
+	
+	if beforeCurrentOffset || afterNextEnd {
+		cb.currentStreamer = nil
+		cb.nextStreamer = nil
+		cb.currentOffset = p
+		cb.currentStreamer = cb.next()
+		return cb.currentStreamer.Seek(0)
+	}
+
+	beforeNextEnd := p < cb.currentOffset + chunkSampleCount * 2
+	afterNextStart := p >= cb.currentOffset + chunkSampleCount
+	
+	if afterNextStart && beforeNextEnd {
+		cb.currentStreamer = cb.next()
+		return cb.currentStreamer.Seek(p - cb.currentOffset)
+	}
+	
+	return cb.currentStreamer.Seek(p - cb.currentOffset)
+}
+
+func (cb *ChunkBufferStreamer) Close() error {
+	if cb.currentStreamer != nil {
+		_ = cb.currentStreamer.Close()
+	}
+
+	if cb.nextStreamer != nil {
+		_ = cb.nextStreamer.Close()
+	}
+
+	return nil
+}
+
+func (cb *ChunkBufferStreamer) Position() int {
+	return cb.currentStreamer.Position() + cb.currentOffset
+}
+
+func (cb *ChunkBufferStreamer) Length() int {
+	return cb.totalSampleCount
+}
+
+func (cb *ChunkBufferStreamer) RequestChunkAtOffset(offset int) io.ReadCloser {
+	rc, _ := cb.RequestSampleRange(offset, offset+chunkSampleCount)
+	return rc
+}
+
+func (cb *ChunkBufferStreamer) RequestSampleRange(start, end int) (io.ReadCloser, *http.Response) {
+	startByte := 4 * start
+	endByte := 4 * end
+
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", startByte, endByte-1)
+	req, _ := http.NewRequest("GET", cb.Episode, nil)
+	req.Header.Set("Range", rangeHeader)
+	resp, _ := http.DefaultClient.Do(req)
+
+	if cb.totalSampleCount == 0 {
+		contentRange := resp.Header.Get("Content-Range")
+		totalByteLength, _ := strconv.Atoi(strings.Split(contentRange, "/")[1])
+		cb.totalSampleCount = totalByteLength / 4
+	}
+
+	return resp.Body, resp
+}
+
+func (cb *ChunkBufferStreamer) next() *ClientStreamer {
+	nextOffset := cb.currentOffset + chunkSampleCount
+	format := beep.Format{}
+	streamer := &ClientStreamer{}
+	nextStreamer := &ClientStreamer{}
+
+	if cb.currentStreamer == nil && cb.nextStreamer == nil {
+		// this is the first streamer starting at the offset in the current streamer
+		// and the second streamer starting at the offset in the next streamer.
+		streamer, format, _ = StreamDecode(cb.RequestChunkAtOffset(cb.currentOffset))
+		cb.currentStreamer = streamer
+		
+		nextStreamer, format, _ = StreamDecode(cb.RequestChunkAtOffset(nextOffset))
+		cb.nextStreamer = nextStreamer
+	}
+
+	if cb.currentStreamer != nil && cb.nextStreamer != nil {
+		// both streamers are populated, so copy nextStreamer to currentStreamer
+		// and initiate the next streamer.
+		cb.currentStreamer = cb.nextStreamer
+
+		if nextOffset < cb.totalSampleCount {
+			streamer, format, _ = StreamDecode(cb.RequestChunkAtOffset(nextOffset))
+			cb.nextStreamer = streamer
+		} else {
+			cb.nextStreamer = nil
+		}
+	}
+
+	cb.currentOffset = nextOffset
+	emptyFormat := beep.Format{}
+	if format == emptyFormat {
+		cb.format = format
+	}
+
+	// These cases should never happen.
+	if cb.currentStreamer == nil && cb.nextStreamer != nil {
+		return nil
+	}
+
+	if cb.currentStreamer != nil && cb.nextStreamer == nil {
+		return nil
+	}
+
+	return cb.currentStreamer
+}

--- a/src/clients/downloader.go
+++ b/src/clients/downloader.go
@@ -11,14 +11,14 @@ type DownloadClient struct {
 	Client *grab.Client
 }
 
-func NewClient() *grab.Client {
+func NewClient() *DownloadClient {
 	// create a client
 	client := grab.NewClient()
 
 	// set the User Agent header
 	client.UserAgent = "Last Player On The Left"
 
-	return client
+	return &DownloadClient{Client: client}
 }
 
 func (c *DownloadClient) CreateRequests(urls []string) (reqs []*grab.Request) {
@@ -35,7 +35,7 @@ func (c *DownloadClient) CreateRequests(urls []string) (reqs []*grab.Request) {
 	return reqs
 }
 
-func (c *DownloadClient) DownloadEpisode(client grab.Client, req *grab.Request) {
+func (c *DownloadClient) DownloadEpisode(req *grab.Request) {
 	fmt.Printf("Downloading %v... \n", req.URL())
 	resp := c.Client.Do(req)
 	fmt.Printf("  %v\n", resp.HTTPResponse.Status)
@@ -75,7 +75,8 @@ Loop:
 	// Download saved to ./gobook.pdf
 }
 
-func (c *DownloadClient) DownloadMulti(client grab.Client, requests ...*grab.Request) {
+func (c *DownloadClient) DownloadMulti(urls ...string) {
+	requests := c.CreateRequests(urls)
 	responses := c.Client.DoBatch(-1, requests...)
 
 	go func() {

--- a/src/clients/tcp_audio.go
+++ b/src/clients/tcp_audio.go
@@ -22,7 +22,7 @@ func StreamDecode(audio io.ReadCloser) (*ClientStreamer, beep.Format, error) {
 	}
 	buff := beep.NewBuffer(format)
 
-	clientStreamer := &ClientStreamer{Buff: buff, inputStreamer: streamer, quit: false}
+	clientStreamer := &ClientStreamer{Buff: buff, inputStreamer: &streamer, quit: false}
 
 	go func() {
 		buff.Append(streamer)
@@ -35,7 +35,7 @@ func StreamDecode(audio io.ReadCloser) (*ClientStreamer, beep.Format, error) {
 
 type ClientStreamer struct {
 	Buff            *beep.Buffer
-	inputStreamer   beep.StreamCloser
+	inputStreamer   *beep.StreamCloser
 	quit            bool
 	currentStreamer beep.StreamSeeker
 }
@@ -96,7 +96,7 @@ func (client *ClientStreamer) next() beep.StreamSeeker {
 }
 
 func (client *ClientStreamer) Close() error {
-	return client.inputStreamer.Close()
+	return (*client.inputStreamer).Close()
 }
 
 func (client *ClientStreamer) Err() error {

--- a/src/view/app_container.go
+++ b/src/view/app_container.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wombatlord/last-player-on-the-left/src/audiopanel"
 	"github.com/wombatlord/last-player-on-the-left/src/clients"
 	"github.com/wombatlord/last-player-on-the-left/src/domain"
+	"io/fs"
 	"log"
 	"os"
 )
@@ -146,12 +147,15 @@ func (lp *LastPlayer) notifyCheck() BeforeDraw {
 // Run overrides the tview.Application Run method and includes a deferred close
 // of the logfile
 func (lp *LastPlayer) Run() error {
+	_ = os.MkdirAll(lp.Config.Cache, fs.ModeDir+fs.FileMode(0774))
 	lp.AudioPanel.SpawnPublisher()
 	defer func(LogFile *os.File) {
 		err := LogFile.Close()
 		if err != nil {
 			log.Fatal(err)
 		}
+		_ = os.RemoveAll(lp.Config.Cache)
+		_ = os.MkdirAll(lp.Config.Cache, fs.ModeDir+fs.FileMode(0774))
 	}(lp.LogFile)
 	return lp.Application.Run()
 }

--- a/src/view/episode_menu.go
+++ b/src/view/episode_menu.go
@@ -39,7 +39,7 @@ func (e *EpisodeMenuController) playEpisode() {
 	e.playingEpisode = &e.lastPlayer.State.Feed.Channel[0].Item[episodeIndex]
 
 	panel := e.lastPlayer.AudioPanel
-	panel.PlayFromUrl(e.playingEpisode.Enclosure.Url, e.lastPlayer.GetLogger("Current Streamer"))
+	panel.PlayFromUrl(e.playingEpisode.Enclosure.Url, e.lastPlayer.GetLogger("Current Streamer"), e.lastPlayer.Config.Cache)
 	go e.lastPlayer.QueueUpdateDraw(func() {
 		e.lastPlayer.State.PlayingEpisode = e.playingEpisode
 	})

--- a/src/view/episode_menu.go
+++ b/src/view/episode_menu.go
@@ -39,7 +39,7 @@ func (e *EpisodeMenuController) playEpisode() {
 	e.playingEpisode = &e.lastPlayer.State.Feed.Channel[0].Item[episodeIndex]
 
 	panel := e.lastPlayer.AudioPanel
-	panel.PlayFromUrl(e.playingEpisode.Enclosure.Url)
+	panel.PlayFromUrl(e.playingEpisode.Enclosure.Url, e.lastPlayer.GetLogger("Current Streamer"))
 	go e.lastPlayer.QueueUpdateDraw(func() {
 		e.lastPlayer.State.PlayingEpisode = e.playingEpisode
 	})


### PR DESCRIPTION
## Additions:
 - A streamer that starts off an async download and then subsequently begins reading the download from the disk, preventing entire episodes from being held in memory. 
 - Episode downloads are kept on disk in the configured cache directory with the filename being the sha1 hash of the episode URL.

## TODO:
 - Remove some of the other older, memory hogging solutions from earlier iterations.